### PR TITLE
IBasicVideoチェックの削除

### DIFF
--- a/NeoMupl/Player/MusicPlayerDS.cs
+++ b/NeoMupl/Player/MusicPlayerDS.cs
@@ -30,13 +30,6 @@ namespace NeoMupl.Player
             realLoopEnd = MusicData.LoopEnd > 0 ? MusicData.LoopEnd : ((IMediaPosition)mediaControl).Duration;
             ((IMediaPosition)mediaControl).Rate = rate;
             ((IMediaPosition)mediaControl).CurrentPosition = from;
-            if (typeof(IBasicVideo).IsInstanceOfType(mediaControl))
-            {
-                // TODO: 必要なら実装しよう(#11)
-#pragma warning disable IDE0059 // 値の不必要な代入
-                IBasicVideo v = (IBasicVideo)mediaControl;
-#pragma warning restore IDE0059 // 値の不必要な代入
-            }
             mediaControl.Run();
         }
         public override void Stop() { mediaControl?.Stop(); }


### PR DESCRIPTION
`MusicPlayerDS.cs`ファイルの`NeoMupl.Player`名前空間において、`mediaControl`が`IBasicVideo`のインスタンスであるかどうかを確認する条件文を削除しました。この変更により、`IBasicVideo`に関連する処理が実装されないことが示されています。

DirectShow側で対応していればこっちで何もしなくても動画が再生される一方、IBasicVideoインターフェースを経由しても画面を消すことはできなさそうだ。 何もする必要はないし、何もできないというのが現在の実情。
そもそも音楽再生アプリなので、動画はサポート外、動いても動かなくても良しということにしておこう。
close #11